### PR TITLE
Make FRACTION_FIELD & SIZE_FIELD depending on FRACTION_SIZE

### DIFF
--- a/src/r32_t.rs
+++ b/src/r32_t.rs
@@ -16,8 +16,8 @@ use super::{ParseRatioErr, RatioErrKind};
 pub struct r32(u32);
 
 const SIGN_BIT: u32 = 0x8000_0000;
-const SIZE_FIELD: u32 = 0x7c00_0000;
-const FRACTION_FIELD: u32 = 0x03ff_ffff;
+const SIZE_FIELD: u32 = SIGN_BIT - 1 << FRACTION_SIZE + 1 >> 1;
+const FRACTION_FIELD: u32 = (1 << FRACTION_SIZE) - 1;
 
 const FRACTION_SIZE: u32 = 26;
 

--- a/src/r64_t.rs
+++ b/src/r64_t.rs
@@ -16,8 +16,8 @@ use super::{ParseRatioErr, RatioErrKind, r32};
 pub struct r64(u64);
 
 const SIGN_BIT: u64 = 0x8000_0000_0000_0000;
-const SIZE_FIELD: u64 = 0x7e00_0000_0000_0000;
-const FRACTION_FIELD: u64 = 0x01ff_ffff_ffff_ffff;
+const SIZE_FIELD: u64 = SIGN_BIT - 1 << FRACTION_SIZE + 1 >> 1;
+const FRACTION_FIELD: u64 = (1 << FRACTION_SIZE) - 1;
 
 const FRACTION_SIZE: u64 = 57;
 


### PR DESCRIPTION
- The SIZE_FIELD and FRACTION_FIELD depend on the FRACTION_SIZE.
  Implementing this dependency enables testing different fraction sizes
  by changing only one variable (instead of three.